### PR TITLE
 (PATCH) - update readme - adding how to import package in controller…

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,19 @@
   
 
 Using npm:
+
 ```bash
     $ npm i -s kkiapay/nodejs-sdk
 ```
 
 ## Initialization
+
+you need to import the package before using it in your controllers.
+
+```js
+// import kkiapay package
+const kkiapay = require('kkiapay-nodejs-sdk');
+```
 
 #### Production
 ```js


### PR DESCRIPTION
Il est difficile pour les juniors ou débutant voulant intégrer kkiapay d'importer le package facilement . J'ne ai pleins de retours.

ils font const kkiapay = require('kkiapay/nodejs-sdk');

Du coup j'ai rajouté le faite que ça soit mis dans le readme pour leur permettre d'aller plus vite ou passer des heures à chercher comment importer les packages

